### PR TITLE
Add dataset catalog link

### DIFF
--- a/progsnap2/index.html
+++ b/progsnap2/index.html
@@ -14,7 +14,7 @@
         activity (typically in an educational setting.) The specification is currently
         in Beta status; several datasets have been implementd using the specification,
         and several analyses performed on them.
-        See the <a href="#current-draft">Current draft</a> section below.
+        See the <a href="#current-draft">Current draft</a> section below, or check out example datasets in the <a target=_blank href="https://splice.cs.vt.edu/datasetcatalog/">CSSPLICE Dataset Catalog</a>.
       </p>
       <p>
         ProgSnap2 was created by the members of the SPLICE Small Code Snapshots
@@ -47,6 +47,8 @@
       </p>
 
       <h2>News</h2>
+      <p>
+        <b>06/26:</b> There are ProgSnap2 datasets in the <a target=_blank href="https://splice.cs.vt.edu/datasetcatalog/">CSSPLICE dataset catalog</a>.
       <p>
         <b>12/20:</b> We have officially transitioned ProgSnap2 into Beta status! Congratulations, everyone!
       </p>
@@ -111,7 +113,7 @@
         There is a <a href="https://github.com/CSSPLICE/progsnap2">GitHub repository</a> that contains some
         converter scripts and some examples.
         [Note: This could use some work.
-        Ideally, someone would add converters and real datasets!]
+        Ideally, someone would add more converters!]
       </p>
     </div>
 


### PR DESCRIPTION
The ProgSnap2 page doesn't currently list any actual datasets, but there are some in the catalog. Just added a link.